### PR TITLE
change default about path_to_mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
           RUN_TASK_ID: ${{ matrix.task.runTaskId }}
           CONTAINER_URL: my/container-url # not mandatory
           FEATURES_TERRAFORM_MODULES: ... # not mandatory
-          PATH_TO_MOUNT: ${{ github_workflow }}
+          PATH_TO_MOUNT: path/to/mount # not mandatory
 ```
 
 * * *
@@ -64,7 +64,7 @@ Field | Mandatory | Observation
 **REPOSITORY_NAME** | YES | Repository name to checkout during task process.
 **CONTAINER_URL** | NO | Container url reference (e.g `stackspot/image`)
 **FEATURES_TERRAFORM_MODULES** | NO | List of external terraform modules allowed
-**PATH_TO_MOUNT** | YES | Path provided to be used as a volume within the docker image that will be used with terraform
+**PATH_TO_MOUNT** | NO | Path provided to be used as a volume within the docker image that will be used with terraform
 
 * * *
 

--- a/action.yaml
+++ b/action.yaml
@@ -43,6 +43,7 @@ inputs:
   PATH_TO_MOUNT:
     description: "Path to mount inside the docker"
     required: true
+    default: ${{ github.workflow }}
 
 runs:
   using: "composite"

--- a/action.yaml
+++ b/action.yaml
@@ -42,8 +42,8 @@ inputs:
     required: false
   PATH_TO_MOUNT:
     description: "Path to mount inside the docker"
-    required: true
-    default: ${{ github.workflow }}
+    required: false
+    default: ${{ github.workspace }}
 
 runs:
   using: "composite"
@@ -61,6 +61,12 @@ runs:
         role-to-assume: ${{ inputs.AWS_ROLE_ARN }}
         aws-region: ${{ inputs.AWS_REGION }}
         output-credentials: true
+    
+    - name: Checkout
+      if: ${{ inputs.PATH_TO_MOUNT == github.workspace }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
       
     - name: Run Runtime Action Deploy
       if: ${{ inputs.AWS_ROLE_ARN == 0 }}


### PR DESCRIPTION
Adding the default for path_to_mount with github.workspace, and if both are the same, we will checkout the branch that is running at that moment