### PR TITLE
Using CHECKOUT_BRANCH to specify files path

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: DEPLOY
         if: contains( matrix.task.taskType , 'DEPLOY')
-        uses: stack-spot/runtime-deploy-action@v2
+        uses: stack-spot/runtime-deploy-action@v2.1
         with:
           FEATURES_LEVEL_LOG: debug
           CLIENT_ID: ${{ secrets.CLIENT_ID }}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Field | Mandatory | Observation
 **OUTPUT_FILE** | NO | Filename where outputs will be saved (default value: `outputs.json`)
 **LOCALEXEC_ENABLED** | NO | Whether or not terraform will be enable to perform local exec operations or not (default: `false`)
 **TF_LOG_PROVIDER** | NO | If there is a need to check Terraform's own log, it is now possible to pass the levels of the Terraform provider, allowing you to analyze what happens within Terraform's CLI (info, trace, debug and warn).
+**CHECKOUT_BRANCH** | NO  | Whether or not checkout is enabled. (default: `'false'`)
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ jobs:
           PATH_TO_MOUNT: path/to/mount
           LOCALEXEC_ENABLED: true # not mandatory
           TF_LOG_PROVIDER: info # not mandatory
+          CHECKOUT_BRANCH: 'true' # not mandatory
 ```
 
 * * *

--- a/action.yaml
+++ b/action.yaml
@@ -59,7 +59,7 @@ inputs:
   CHECKOUT_BRANCH:
     description: "Whether or not checkout is enabled."
     required: false
-    default: false
+    default: 'false'
     
 
 runs:

--- a/action.yaml
+++ b/action.yaml
@@ -56,10 +56,18 @@ inputs:
   TF_LOG_PROVIDER:
     description: "Level tf log provider - info, debug, warn or trace"
     required: false
+  CHECKOUT_BRANCH:
+    description: "Whether or not checkout is enabled."
+    required: false
+    default: 'false'
+    
 
 runs:
   using: "composite"
   steps:
+    - name: Checkout
+      if: inputs.CHECKOUT_BRANCH == 'true'
+      uses: actions/checkout@v4
       
     - name: Check Runner
       run: echo 🤖 OS runner is $(uname)

--- a/action.yaml
+++ b/action.yaml
@@ -66,7 +66,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      if: inputs.CHECKOUT_BRANCH == true
+      if: inputs.CHECKOUT_BRANCH == 'true'
       uses: actions/checkout@v4
       
     - name: Check Runner

--- a/action.yaml
+++ b/action.yaml
@@ -66,7 +66,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      if: inputs.CHECKOUT_BRANCH == 'true'
+      if: inputs.CHECKOUT_BRANCH != 'false'
       uses: actions/checkout@v4
       
     - name: Check Runner

--- a/action.yaml
+++ b/action.yaml
@@ -59,14 +59,14 @@ inputs:
   CHECKOUT_BRANCH:
     description: "Whether or not checkout is enabled."
     required: false
-    default: 'false'
+    default: false
     
 
 runs:
   using: "composite"
   steps:
     - name: Checkout
-      if: inputs.CHECKOUT_BRANCH == 'true'
+      if: inputs.CHECKOUT_BRANCH == true
       uses: actions/checkout@v4
       
     - name: Check Runner


### PR DESCRIPTION
# Context
issue: https://github.com/stack-spot/runtime-deploy-action/issues/14
It has been seen in several cases where shared infrastructure and applications are created in which it is necessary to clone the files from the repository to the root of the deploy, the objective of the problem is to bring a solution that the client can add to the file path.

## ▶️ Action Inputs

Field | Mandatory | Default Value | Observation
------------ | ------------  | ------------- | -------------
**CHECKOUT_BRANCH** | NO | false | Whether or not checkout is enabled.

